### PR TITLE
Minor improvements to tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,10 +6,6 @@ publish = false
 
 [lib]
 crate-type = ["cdylib", "rlib"]
-# Crate contains no rust docs or doctests as it is not published to docs.rs.
-doctest = false
-# Crate contains no tests, and all tests live outside in the tests folder.
-test = false
 
 [features]
 default = ["console_error_panic_hook"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,10 @@ publish = false
 
 [lib]
 crate-type = ["cdylib", "rlib"]
+# Crate contains no rust docs or doctests as it is not published to docs.rs.
+doctest = false
+# Crate contains no tests, and all tests live outside in the tests folder.
+test = false
 
 [features]
 default = ["console_error_panic_hook"]

--- a/Makefile
+++ b/Makefile
@@ -13,4 +13,5 @@ clean:
 	rm -fr pkg pkg-deno
 
 test:
+	cargo test
 	wasm-pack test --headless --firefox

--- a/Makefile
+++ b/Makefile
@@ -13,5 +13,5 @@ clean:
 	rm -fr pkg pkg-deno
 
 test:
-	cargo test
+	cargo test --test tests
 	wasm-pack test --headless --firefox

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,6 +1,5 @@
 //! Test suite for the Web and headless browsers.
 
-
 #[cfg(target_arch = "wasm32")]
 extern crate wasm_bindgen_test;
 #[cfg(target_arch = "wasm32")]

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,15 +1,16 @@
 //! Test suite for the Web and headless browsers.
 
-#![cfg(target_arch = "wasm32")]
 
+#[cfg(target_arch = "wasm32")]
 extern crate wasm_bindgen_test;
+#[cfg(target_arch = "wasm32")]
 use wasm_bindgen_test::*;
 
-use std::assert_eq;
-
+#[cfg(target_arch = "wasm32")]
 wasm_bindgen_test_configure!(run_in_browser);
 
-#[wasm_bindgen_test]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+#[test]
 fn pass() {
     assert_eq!(
         stellar_xdr_json::types(),
@@ -440,5 +441,17 @@ fn pass() {
             "HmacSha256Key",
             "HmacSha256Mac"
         ]
+    );
+}
+
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+#[test]
+fn decode_success() {
+    assert_eq!(
+        stellar_xdr_json::decode(
+            "TransactionEnvelope".to_string(),
+            "AAAAAgAAAADgEZSKvj9N4hWo7xlEDhSTfZRRnmodlACjhT0/BweuyQAAAGUB/G2bAC33IQAAAAEAAAAAAAAAAAAAAABmzOtiAAAAAAAAAAEAAAAAAAAADAAAAAAAAAABVEZDAAAAAADlu40gByuPMTgEkGkhjz5+CDc95FS7T+ywnU7hWCVE1QAAAABpKduDAADRYQCYloAAAAAAXqLzMgAAAAAAAAABBweuyQAAAEC6TCDlbRpjth9ySEI2QiZ2s4CqERXVRvQC45SGPsO16sfQoNwbvBr1C3K9Cu5De/QdPpBQedwArheCWreq2KMJ".to_string(),
+        ),
+        Ok("{\"tx\":{\"tx\":{\"source_account\":\"GDQBDFEKXY7U3YQVVDXRSRAOCSJX3FCRTZVB3FAAUOCT2PYHA6XMSJZK\",\"fee\":101,\"seq_num\":143109800659384097,\"cond\":{\"time\":{\"min_time\":0,\"max_time\":1724705634}},\"memo\":\"none\",\"operations\":[{\"source_account\":null,\"body\":{\"manage_buy_offer\":{\"selling\":\"native\",\"buying\":{\"credit_alphanum4\":{\"asset_code\":\"TFC\",\"issuer\":\"GDS3XDJAA4VY6MJYASIGSIMPHZ7AQNZ54RKLWT7MWCOU5YKYEVCNLVS3\"}},\"buy_amount\":1764350851,\"price\":{\"n\":53601,\"d\":10000000},\"offer_id\":1587737394}}}],\"ext\":\"v0\"},\"signatures\":[{\"hint\":\"0707aec9\",\"signature\":\"ba4c20e56d1a63b61f72484236422676b380aa1115d546f402e394863ec3b5eac7d0a0dc1bbc1af50b72bd0aee437bf41d3e905079dc00ae17825ab7aad8a309\"}]}}".to_string()),
     );
 }


### PR DESCRIPTION
### What
Added a decode test, and changed tests so they run both locally as rust tests as well as in browser wasm tests.

### Why
There was no decode test.

Tests were written so they only ran in the browser compiled to wasm. It is helpful to be able to run them locally as just rust for fast iteration and to identify problems that are unique to the wasm environment vs logical issues.