### PR TITLE
Add bump-version workflow

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,0 +1,15 @@
+name: Bump Version
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to bump to'
+        required: true
+
+jobs:
+
+  bump-version:
+    uses: stellar/actions/.github/workflows/rust-bump-version.yml@main
+    with:
+      version: ${{ inputs.version }}


### PR DESCRIPTION
### What
Add bump-version workflow

### Why
For the typical rust release process.