### PR TITLE
Update wasm-pack

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
         node-version: '18.x'
         registry-url: 'https://registry.npmjs.org'
         always-auth: true
-    - uses: stellar/binaries@v23
+    - uses: stellar/binaries@v31
       with:
         name: wasm-pack
         version: 0.13.0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
     - uses: stellar/binaries@v23
       with:
         name: wasm-pack
-        version: 0.12.1
+        version: 0.13.0
     - uses: stellar/binaries@v23
       with:
         name: wasm-bindgen-cli

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -56,7 +56,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: stellar/actions/rust-cache@main
-    - uses: stellar/binaries@v23
+    - uses: stellar/binaries@v31
       with:
         name: wasm-pack
         version: 0.13.0

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -59,7 +59,7 @@ jobs:
     - uses: stellar/binaries@v23
       with:
         name: wasm-pack
-        version: 0.12.1
+        version: 0.13.0
     - uses: stellar/binaries@v23
       with:
         name: wasm-bindgen-cli


### PR DESCRIPTION
### What
Update wasm-pack

### Why
To get a bug fix that was added in 0.13. The `main` property is not included in the package.json in the current release, but 0.13 fixed that property being set.

Depends on:
- https://github.com/stellar/binaries/pull/33

Related to:
- https://github.com/denoland/deno/issues/26132