### PR TITLE
Remove different types of packages

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
         node-version: '18.x'
         registry-url: 'https://registry.npmjs.org'
         always-auth: true
-    - uses: stellar/binaries@v23
+    - uses: stellar/binaries@v31
       with:
         name: wasm-pack
         version: 0.13.0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
     - uses: stellar/binaries@v23
       with:
         name: wasm-pack
-        version: 0.12.1
+        version: 0.13.0
     - uses: stellar/binaries@v23
       with:
         name: wasm-bindgen-cli

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -56,7 +56,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: stellar/actions/rust-cache@main
-    - uses: stellar/binaries@v23
+    - uses: stellar/binaries@v31
       with:
         name: wasm-pack
         version: 0.13.0

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -59,7 +59,7 @@ jobs:
     - uses: stellar/binaries@v23
       with:
         name: wasm-pack
-        version: 0.12.1
+        version: 0.13.0
     - uses: stellar/binaries@v23
       with:
         name: wasm-bindgen-cli

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -71,11 +71,6 @@ jobs:
     - run: make build
     - uses: actions/upload-artifact@v4
       with:
-        name: web
-        path: pkg/web
-    - uses: actions/upload-artifact@v4
-      with:
-        name: deno
-        path: pkg/deno
+        path: pkg
     - run: make test
     - run: git add -N . && git diff HEAD --exit-code

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,9 @@
-build: build-web build-deno
-
-build-web: clean
+build: clean
 	wasm-pack build --release --target web
-	sed -i'.bak' -e 's#"stellar-xdr-json"#"@stellar/stellar-xdr-json-web"#' pkg/package.json
-	ls -lah pkg/*.wasm
-
-build-deno: clean
-	wasm-pack build --release --target deno --out-dir pkg-deno
 	ls -lah pkg/*.wasm
 
 clean:
-	rm -fr pkg pkg-deno
+	rm -fr pkg
 
 test:
 	cargo test --test tests


### PR DESCRIPTION
### What
Remove different types of packages and publish one without the -web suffix.

### Why
In the latest version of wasm-pack the web target seems to work across the browser, node, and deno just fine and we don't need to go down a path where there are multiple packages. It also appears on issues that there's an effort to make the packages it generates more generally compatible across more environments.

This will result in a new package getting published `@stellar/stellar-xdr-json` instead of `@stellar/stellar-xdr-json-web`. We will need to mark the old package as deprecated.

### Merging
Intended for merging to `main` after #11.