### PR TITLE
Fix package name to have `@stellar` namespace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 build: clean
 	wasm-pack build --release --target web
+	sed -i'.bak' -e 's#"stellar-xdr-json"#"@stellar/stellar-xdr-json"#' pkg/package.json
 	ls -lah pkg/*.wasm
 
 clean:


### PR DESCRIPTION
### What
Fix package name to have `@stellar` namespace

### Why
I accidentally removed the namespace in:
- #12