### PR TITLE
Simplify api of using the package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 build: clean
 	wasm-pack build --release --target web
-	deno --allow-read=pkg/ --allow-write=pkg/ scripts/post-build.ts
+	node scripts/post-build.mjs
 	ls -lah pkg/*.wasm pkg/*.js
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 build: clean
 	wasm-pack build --release --target web
-	sed -i'.bak' -e 's#"stellar-xdr-json"#"@stellar/stellar-xdr-json"#' pkg/package.json
-	ls -lah pkg/*.wasm
+	deno --allow-read=pkg/ --allow-write=pkg/ scripts/post-build.ts
+	ls -lah pkg/*.wasm pkg/*.js
 
 clean:
 	rm -fr pkg

--- a/scripts/post-build.mjs
+++ b/scripts/post-build.mjs
@@ -1,37 +1,37 @@
-import { encodeBase64 } from "jsr:@std/encoding@1.0.5/base64";
+import fs from "node:fs";
 
 // Rename the package to include the @stellar namespace.
 {
     const file = "pkg/package.json";
-    const input = Deno.readTextFileSync(file);
+    const input = fs.readFileSync(file, "utf8");
     const output = input.replaceAll(
         "stellar-xdr-json",
         "@stellar/stellar-xdr-json",
     );
-    Deno.writeTextFileSync(file, output);
+    fs.writeFileSync(file, output);
 }
 
 // Embed the wasm file into the js.
 {
-    const wasm = Deno.readFileSync("pkg/stellar_xdr_json_bg.wasm");
-    const wasm_b64 = encodeBase64(wasm);
+    const wasm = fs.readFileSync("pkg/stellar_xdr_json_bg.wasm");
+    const wasm_b64 = wasm.toString("base64");
 
     const file = "pkg/stellar_xdr_json.js";
-    const input = Deno.readTextFileSync(file);
+    const input = fs.readFileSync(file, "utf8");
     const output = input.replaceAll(
         "stellar_xdr_json_bg.wasm",
         `data:application/wasm;base64,${wasm_b64}`,
     );
-    Deno.writeTextFileSync(file, output);
+    fs.writeFileSync(file, output);
 }
 
 // Unexport the wasm initialization and run it automatically
 {
     const file = "pkg/stellar_xdr_json.js";
-    const input = Deno.readTextFileSync(file);
+    const input = fs.readFileSync(file, "utf8");
     const output = input.replaceAll(
         "export default __wbg_init;",
         "await __wbg_init();",
     );
-    Deno.writeTextFileSync(file, output);
+    fs.writeFileSync(file, output);
 }

--- a/scripts/post-build.ts
+++ b/scripts/post-build.ts
@@ -1,0 +1,37 @@
+import { encodeBase64 } from "jsr:@std/encoding@1.0.5/base64";
+
+// Rename the package to include the @stellar namespace.
+{
+    const file = "pkg/package.json";
+    const input = Deno.readTextFileSync(file);
+    const output = input.replaceAll(
+        "stellar-xdr-json",
+        "@stellar/stellar-xdr-json",
+    );
+    Deno.writeTextFileSync(file, output);
+}
+
+// Embed the wasm file into the js.
+{
+    const wasm = Deno.readFileSync("pkg/stellar_xdr_json_bg.wasm");
+    const wasm_b64 = encodeBase64(wasm);
+
+    const file = "pkg/stellar_xdr_json.js";
+    const input = Deno.readTextFileSync(file);
+    const output = input.replaceAll(
+        "stellar_xdr_json_bg.wasm",
+        `data:application/wasm;base64,${wasm_b64}`,
+    );
+    Deno.writeTextFileSync(file, output);
+}
+
+// Unexport the wasm initialization and run it automatically
+{
+    const file = "pkg/stellar_xdr_json.js";
+    const input = Deno.readTextFileSync(file);
+    const output = input.replaceAll(
+        "export default __wbg_init;",
+        "await __wbg_init();",
+    );
+    Deno.writeTextFileSync(file, output);
+}


### PR DESCRIPTION
### What
Embed the .wasm file into the .js file, and load it automatically.

### Why
Make the rust wasm compiled to js package a better experience to use, so that it looks like any other js package.

Eliminates the need to navigate loading the .wasm file.

Makes the API of the package like the API of any other package, where it just has the functions to call.

The idea has been floated on wasm-pack as a type of new target, "inline," but it hasn't eventuated into an implementation yet:
- https://github.com/rustwasm/wasm-pack/issues/1334
- https://github.com/rustwasm/wasm-pack/issues/699
- https://github.com/rustwasm/wasm-pack/issues/831
- https://github.com/rustwasm/wasm-pack/issues/1074

But we can do the same thing with a little file manipulation.

### Why Not

Could break in the future when we update wasm-pack versions.

There could be situations where an application wants to defer loading the wasm until it'll be used. This solution definitely impacts on any ability to do that.