### PR TITLE
Add depth limits to XDR parsing functions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -41,7 +41,7 @@ jobs:
     continue-on-error: ${{ matrix.checks == 'advisories' }}
     steps:
     - uses: actions/checkout@v3
-    - uses: EmbarkStudios/cargo-deny-action@30f817c6f72275c6d54dc744fbca09ebc958599f
+    - uses: EmbarkStudios/cargo-deny-action@3fd3802e88374d3fe9159b834c7714ec57d6c979
       with:
         command: check ${{ matrix.checks }}
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,9 @@ use std::str::FromStr;
 use stellar_xdr::curr::{Limited, Limits, Type, TypeVariant, WriteXdr};
 use wasm_bindgen::prelude::*;
 
+// This is set to mirror https://github.com/stellar/rs-soroban-env/blob/main/soroban-env-host/src/budget/limits.rs#L14
+const XDR_MAX_DEPTH: u32 = 500;
+
 /// Returns a list of XDR types.
 #[wasm_bindgen]
 pub fn types() -> Vec<String> {
@@ -35,8 +38,12 @@ pub fn guess(xdr_base64: String) -> Vec<String> {
     // Base64 when decoded will have a length at or under this len.
     // Ref: https://datatracker.ietf.org/doc/html/rfc4648#page-5
     let decoded_max_len = xdr_base64.len() / 4 * 3;
-    // Limit decoding attempts to within the maximum length of the known input.
-    let limits = Limits::len(decoded_max_len);
+    // Limit decoding attempts to within the maximum length of the known input
+    // and the maximum supported depth of XDR structures.
+    let limits = Limits {
+        len: decoded_max_len,
+        depth: XDR_MAX_DEPTH,
+    };
 
     TypeVariant::VARIANTS
         .iter()
@@ -57,8 +64,12 @@ pub fn decode_stream(type_variant: String, xdr_base64: String) -> Result<Vec<Str
     // Base64 when decoded will have a length at or under this len.
     // Ref: https://datatracker.ietf.org/doc/html/rfc4648#page-5
     let decoded_max_len = xdr_base64.len() / 4 * 3;
-    // Limit decoding attempts to within the maximum length of the known input.
-    let limits = Limits::len(decoded_max_len);
+    // Limit decoding attempts to within the maximum length of the known input
+    // and the maximum supported depth of XDR structures.
+    let limits = Limits {
+        len: decoded_max_len,
+        depth: XDR_MAX_DEPTH,
+    };
     let mut cursor = Limited::new(Cursor::new(xdr_base64.as_bytes()), limits);
 
     let json = Type::read_xdr_base64_iter(type_variant, &mut cursor)
@@ -85,8 +96,12 @@ pub fn decode(type_variant: String, xdr_base64: String) -> Result<String, String
     // Base64 when decoded will have a length at or under this len.
     // Ref: https://datatracker.ietf.org/doc/html/rfc4648#page-5
     let decoded_max_len = xdr_base64.len() / 4 * 3;
-    // Limit decoding attempts to within the maximum length of the known input.
-    let limits = Limits::len(decoded_max_len);
+    // Limit decoding attempts to within the maximum length of the known input
+    // and the maximum supported depth of XDR structures.
+    let limits = Limits {
+        len: decoded_max_len,
+        depth: XDR_MAX_DEPTH,
+    };
 
     let value =
         Type::from_xdr_base64(type_variant, xdr_base64, limits).map_err(|e| format!("{e}"))?;
@@ -111,7 +126,7 @@ pub fn encode(type_variant: String, json: String) -> Result<String, String> {
     // let t: Type = serde_wasm_bindgen::from_value(js).map_err(|e| format!("{e}"))?;
     let t = Type::from_json(type_variant, json.as_bytes()).map_err(|e| format!("{e}"))?;
     let b64 = t
-        .to_xdr_base64(Limits::none())
+        .to_xdr_base64(Limits::depth(XDR_MAX_DEPTH))
         .map_err(|e| format!("{e}"))?;
     Ok(b64)
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,5 +1,7 @@
 //! Test suite for the Web and headless browsers.
 
+use stellar_xdr::curr::{Limits, ScVal, ScVec, VecM, WriteXdr};
+
 #[cfg(target_arch = "wasm32")]
 extern crate wasm_bindgen_test;
 #[cfg(target_arch = "wasm32")]
@@ -7,6 +9,23 @@ use wasm_bindgen_test::*;
 
 #[cfg(target_arch = "wasm32")]
 wasm_bindgen_test_configure!(run_in_browser);
+
+/// Build a base64-encoded XDR ScVal with `depth` levels of nested ScVec,
+/// each containing a single element, with an ScVal::U32(0) at the innermost level.
+///
+/// Each nesting level consumes 4 depth units in stellar-xdr because the
+/// read path passes through 4 `with_limited_depth` calls:
+///   ScVal (union) → Option<ScVec> (pointer) → ScVec (typedef) → VecM<ScVal> (var-length array)
+fn build_nested_scval_xdr(depth: usize) -> String {
+    let mut val = ScVal::U32(0);
+    for _ in 0..depth / 4 {
+        val = ScVal::Vec(Some(ScVec(VecM::try_from(vec![val]).unwrap())));
+    }
+    val.to_xdr_base64(Limits::none()).unwrap()
+}
+
+// TxEnvelope
+const TX_ENV_XDR: &str = "AAAAAgAAAADgEZSKvj9N4hWo7xlEDhSTfZRRnmodlACjhT0/BweuyQAAAGUB/G2bAC33IQAAAAEAAAAAAAAAAAAAAABmzOtiAAAAAAAAAAEAAAAAAAAADAAAAAAAAAABVEZDAAAAAADlu40gByuPMTgEkGkhjz5+CDc95FS7T+ywnU7hWCVE1QAAAABpKduDAADRYQCYloAAAAAAXqLzMgAAAAAAAAABBweuyQAAAEC6TCDlbRpjth9ySEI2QiZ2s4CqERXVRvQC45SGPsO16sfQoNwbvBr1C3K9Cu5De/QdPpBQedwArheCWreq2KMJ";
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 #[test]
@@ -487,10 +506,18 @@ fn decode_success() {
     assert_eq!(
         stellar_xdr_json::decode(
             "TransactionEnvelope".to_string(),
-            "AAAAAgAAAADgEZSKvj9N4hWo7xlEDhSTfZRRnmodlACjhT0/BweuyQAAAGUB/G2bAC33IQAAAAEAAAAAAAAAAAAAAABmzOtiAAAAAAAAAAEAAAAAAAAADAAAAAAAAAABVEZDAAAAAADlu40gByuPMTgEkGkhjz5+CDc95FS7T+ywnU7hWCVE1QAAAABpKduDAADRYQCYloAAAAAAXqLzMgAAAAAAAAABBweuyQAAAEC6TCDlbRpjth9ySEI2QiZ2s4CqERXVRvQC45SGPsO16sfQoNwbvBr1C3K9Cu5De/QdPpBQedwArheCWreq2KMJ".to_string(),
+            TX_ENV_XDR.to_string(),
         ),
         Ok("{\"tx\":{\"tx\":{\"source_account\":\"GDQBDFEKXY7U3YQVVDXRSRAOCSJX3FCRTZVB3FAAUOCT2PYHA6XMSJZK\",\"fee\":101,\"seq_num\":\"143109800659384097\",\"cond\":{\"time\":{\"min_time\":\"0\",\"max_time\":\"1724705634\"}},\"memo\":\"none\",\"operations\":[{\"source_account\":null,\"body\":{\"manage_buy_offer\":{\"selling\":\"native\",\"buying\":{\"credit_alphanum4\":{\"asset_code\":\"TFC\",\"issuer\":\"GDS3XDJAA4VY6MJYASIGSIMPHZ7AQNZ54RKLWT7MWCOU5YKYEVCNLVS3\"}},\"buy_amount\":\"1764350851\",\"price\":{\"n\":53601,\"d\":10000000},\"offer_id\":\"1587737394\"}}}],\"ext\":\"v0\"},\"signatures\":[{\"hint\":\"0707aec9\",\"signature\":\"ba4c20e56d1a63b61f72484236422676b380aa1115d546f402e394863ec3b5eac7d0a0dc1bbc1af50b72bd0aee437bf41d3e905079dc00ae17825ab7aad8a309\"}]}}".to_string()),
     );
+}
+
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+#[test]
+fn decode_failure() {
+    let truncated_xdr = TX_ENV_XDR[..TX_ENV_XDR.len() - 1].to_string();
+
+    assert!(stellar_xdr_json::decode("TransactionEnvelope".to_string(), truncated_xdr,).is_err());
 }
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
@@ -515,11 +542,30 @@ fn decode_iter_success() {
 #[test]
 fn decode_length_limit_protection() {
     assert_eq!(
-        stellar_xdr_json::decode(
-            "ScMetaV0".to_string(),
-            "AAAAAgAAAADgEZSKvj9N4hWo7xlEDhSTfZRRnmodlACjhT0/BweuyQAAAGUB/G2bAC33IQAAAAEAAAAAAAAAAAAAAABmzOtiAAAAAAAAAAEAAAAAAAAADAAAAAAAAAABVEZDAAAAAADlu40gByuPMTgEkGkhjz5+CDc95FS7T+ywnU7hWCVE1QAAAABpKduDAADRYQCYloAAAAAAXqLzMgAAAAAAAAABBweuyQAAAEC6TCDlbRpjth9ySEI2QiZ2s4CqERXVRvQC45SGPsO16sfQoNwbvBr1C3K9Cu5De/QdPpBQedwArheCWreq2KMJ".to_string(),
-        ),
+        stellar_xdr_json::decode("ScMetaV0".to_string(), TX_ENV_XDR.to_string()),
         Err("length limit exceeded".to_string()),
+    );
+}
+
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+#[test]
+fn decode_depth_limit_protection() {
+    assert!(stellar_xdr_json::decode("ScVal".to_string(), build_nested_scval_xdr(499)).is_ok());
+    assert_eq!(
+        stellar_xdr_json::decode("ScVal".to_string(), build_nested_scval_xdr(500)),
+        Err("depth limit exceeded".to_string()),
+    );
+}
+
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+#[test]
+fn decode_stream_depth_limit_protection() {
+    assert!(
+        stellar_xdr_json::decode_stream("ScVal".to_string(), build_nested_scval_xdr(499)).is_ok()
+    );
+    assert_eq!(
+        stellar_xdr_json::decode_stream("ScVal".to_string(), build_nested_scval_xdr(500)),
+        Err("depth limit exceeded".to_string()),
     );
 }
 
@@ -527,10 +573,20 @@ fn decode_length_limit_protection() {
 #[test]
 fn guess() {
     assert_eq!(
-        stellar_xdr_json::guess("AAAAAgAAAADgEZSKvj9N4hWo7xlEDhSTfZRRnmodlACjhT0/BweuyQAAAGUB/G2bAC33IQAAAAEAAAAAAAAAAAAAAABmzOtiAAAAAAAAAAEAAAAAAAAADAAAAAAAAAABVEZDAAAAAADlu40gByuPMTgEkGkhjz5+CDc95FS7T+ywnU7hWCVE1QAAAABpKduDAADRYQCYloAAAAAAXqLzMgAAAAAAAAABBweuyQAAAEC6TCDlbRpjth9ySEI2QiZ2s4CqERXVRvQC45SGPsO16sfQoNwbvBr1C3K9Cu5De/QdPpBQedwArheCWreq2KMJ".to_string()),
-        &[
-            "FeeBumpTransactionInnerTx",
-            "TransactionEnvelope",
-        ],
+        stellar_xdr_json::guess(TX_ENV_XDR.to_string()),
+        &["FeeBumpTransactionInnerTx", "TransactionEnvelope",],
+    );
+}
+
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+#[test]
+fn guess_depth_limit_protection() {
+    assert_eq!(
+        stellar_xdr_json::guess(build_nested_scval_xdr(499)),
+        &["ScVal"],
+    );
+    assert_eq!(
+        stellar_xdr_json::guess(build_nested_scval_xdr(500)),
+        &[] as &[String],
     );
 }


### PR DESCRIPTION
### What

Add a XDR_MAX_DEPTH constant of 500 and apply it to all decoding functions (decode, decode_stream, guess) and the encode function. This mirrors the depth limits in the Soroban host env.

Note - the actual limits can be different due to limits imposed by `serde`. The JSON parser used has a max depth limit of 128, but XDR depth does not map to JSON depth directly.

### Why

Deeply nested XDRs can cause un-expected panics instead of errors.

### Known Limitations

None