### PR TITLE
chore: update publish to use trusted publishers instead of token

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,3 +32,5 @@ jobs:
         version: 0.2.92
     - run: make build
     - run: wasm-pack publish --access=public --target web
+      env:
+        NPM_CONFIG_PROVENANCE: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,19 +4,24 @@ on:
   release:
     types: [published]
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
 
   publish:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Install Node
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
-        node-version: '18.x'
+        node-version: '20.x'
         registry-url: 'https://registry.npmjs.org'
-        always-auth: true
+    - name: Upgrade npm for OIDC trusted publishing
+      run: npm install -g npm@^11.5.1
     - uses: stellar/binaries@v31
       with:
         name: wasm-pack
@@ -27,5 +32,3 @@ jobs:
         version: 0.2.92
     - run: make build
     - run: wasm-pack publish --access=public --target web
-      env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "stellar-xdr-json"
 version = "23.0.1"
 edition = "2021"
 publish = false
+repository = "https://github.com/stellar/js-stellar-xdr-json"
 rust-version = "1.86.0"
 
 [lib]


### PR DESCRIPTION
### What

Updates the `publish` workflow to use trusted publishing. Adds the repository URL to the cargo.toml so wasm-pack includes it in the package.json.

### Why

Stellar has migrated to this format instead of NPM_TOKEN
