### PR TITLE
Update stellar-xdr to 26.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -207,9 +207,9 @@ checksum = "2bfcf67fea2815c2fc3b90873fae90957be12ff417335dfadc7f52927feb03b2"
 
 [[package]]
 name = "ethnum"
-version = "1.5.2"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
+checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
 
 [[package]]
 name = "fnv"
@@ -543,9 +543,9 @@ dependencies = [
 
 [[package]]
 name = "stellar-xdr"
-version = "23.0.0"
+version = "26.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89d2848e1694b0c8db81fd812bfab5ea71ee28073e09ccc45620ef3cf7a75a9b"
+checksum = "ea6e29c7e1f071c2767916460d006668197843d5d93f0ec8893a26f72a14f595"
 dependencies = [
  "base64",
  "cfg_eval",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ console_error_panic_hook = { version = "0.1.7", optional = true }
 # serde-wasm-bindgen = "0.6.5"
 
 [dependencies.stellar-xdr]
-version = "23.0.0"
+version = "26.0.1"
 features = ["std", "curr", "base64", "serde", "serde_json", "schemars"]
 # git = "https://github.com/stellar/rs-stellar-xdr"
 # rev = "89a8bcde36aeda551cb0e3f9aa3e9fcf315fe1cc"

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,6 +1,8 @@
 //! Test suite for the Web and headless browsers.
 
-use stellar_xdr::curr::{Limits, ScVal, ScVec, VecM, WriteXdr};
+use stellar_xdr::curr::{
+    Int128Parts, Int256Parts, Limits, ScVal, ScVec, UInt128Parts, UInt256Parts, VecM, WriteXdr,
+};
 
 #[cfg(target_arch = "wasm32")]
 extern crate wasm_bindgen_test;
@@ -44,6 +46,7 @@ fn list_of_types() {
             "ScpStatementExternalize",
             "ScpEnvelope",
             "ScpQuorumSet",
+            "EncodedLedgerKey",
             "ConfigSettingContractExecutionLanesV0",
             "ConfigSettingContractComputeV0",
             "ConfigSettingContractParallelComputeV0",
@@ -57,6 +60,10 @@ fn list_of_types() {
             "StateArchivalSettings",
             "EvictionIterator",
             "ConfigSettingScpTiming",
+            "FrozenLedgerKeys",
+            "FrozenLedgerKeysDelta",
+            "FreezeBypassTxs",
+            "FreezeBypassTxsDelta",
             "ContractCostParams",
             "ConfigSettingId",
             "ConfigSettingEntry",
@@ -588,5 +595,113 @@ fn guess_depth_limit_protection() {
     assert_eq!(
         stellar_xdr_json::guess(build_nested_scval_xdr(500)),
         &[] as &[String],
+    );
+}
+
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+#[test]
+fn decode_uint128_parts_renders_as_string() {
+    let value = UInt128Parts { hi: 1, lo: 2 };
+    let xdr = value.to_xdr_base64(Limits::none()).unwrap();
+    assert_eq!(
+        stellar_xdr_json::decode("UInt128Parts".to_string(), xdr),
+        Ok("\"18446744073709551618\"".to_string()),
+    );
+}
+
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+#[test]
+fn decode_int128_parts_renders_as_string() {
+    let value = Int128Parts { hi: 1, lo: 2 };
+    let xdr = value.to_xdr_base64(Limits::none()).unwrap();
+    assert_eq!(
+        stellar_xdr_json::decode("Int128Parts".to_string(), xdr),
+        Ok("\"18446744073709551618\"".to_string()),
+    );
+}
+
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+#[test]
+fn decode_uint256_parts_renders_as_string() {
+    let value = UInt256Parts {
+        hi_hi: 1,
+        hi_lo: 2,
+        lo_hi: 3,
+        lo_lo: 4,
+    };
+    let xdr = value.to_xdr_base64(Limits::none()).unwrap();
+    assert_eq!(
+        stellar_xdr_json::decode("UInt256Parts".to_string(), xdr),
+        Ok("\"6277101735386680764516354157049543343084444891548699590660\"".to_string()),
+    );
+}
+
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+#[test]
+fn decode_int256_parts_renders_as_string() {
+    let value = Int256Parts {
+        hi_hi: 1,
+        hi_lo: 2,
+        lo_hi: 3,
+        lo_lo: 4,
+    };
+    let xdr = value.to_xdr_base64(Limits::none()).unwrap();
+    assert_eq!(
+        stellar_xdr_json::decode("Int256Parts".to_string(), xdr),
+        Ok("\"6277101735386680764516354157049543343084444891548699590660\"".to_string()),
+    );
+}
+
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+#[test]
+fn decode_scval_u128_renders_as_string() {
+    let value = ScVal::U128(UInt128Parts { hi: 1, lo: 2 });
+    let xdr = value.to_xdr_base64(Limits::none()).unwrap();
+    assert_eq!(
+        stellar_xdr_json::decode("ScVal".to_string(), xdr),
+        Ok("{\"u128\":\"18446744073709551618\"}".to_string()),
+    );
+}
+
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+#[test]
+fn decode_scval_i128_renders_as_string() {
+    let value = ScVal::I128(Int128Parts { hi: 1, lo: 2 });
+    let xdr = value.to_xdr_base64(Limits::none()).unwrap();
+    assert_eq!(
+        stellar_xdr_json::decode("ScVal".to_string(), xdr),
+        Ok("{\"i128\":\"18446744073709551618\"}".to_string()),
+    );
+}
+
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+#[test]
+fn decode_scval_u256_renders_as_string() {
+    let value = ScVal::U256(UInt256Parts {
+        hi_hi: 1,
+        hi_lo: 2,
+        lo_hi: 3,
+        lo_lo: 4,
+    });
+    let xdr = value.to_xdr_base64(Limits::none()).unwrap();
+    assert_eq!(
+        stellar_xdr_json::decode("ScVal".to_string(), xdr),
+        Ok("{\"u256\":\"6277101735386680764516354157049543343084444891548699590660\"}".to_string()),
+    );
+}
+
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+#[test]
+fn decode_scval_i256_renders_as_string() {
+    let value = ScVal::I256(Int256Parts {
+        hi_hi: 1,
+        hi_lo: 2,
+        lo_hi: 3,
+        lo_lo: 4,
+    });
+    let xdr = value.to_xdr_base64(Limits::none()).unwrap();
+    assert_eq!(
+        stellar_xdr_json::decode("ScVal".to_string(), xdr),
+        Ok("{\"i256\":\"6277101735386680764516354157049543343084444891548699590660\"}".to_string()),
     );
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -622,6 +622,17 @@ fn decode_int128_parts_renders_as_string() {
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 #[test]
+fn decode_int128_parts_renders_as_string_negative() {
+    let value = Int128Parts { hi: -1, lo: 0 };
+    let xdr = value.to_xdr_base64(Limits::none()).unwrap();
+    assert_eq!(
+        stellar_xdr_json::decode("Int128Parts".to_string(), xdr),
+        Ok("\"-18446744073709551616\"".to_string()),
+    );
+}
+
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+#[test]
 fn decode_uint256_parts_renders_as_string() {
     let value = UInt256Parts {
         hi_hi: 1,
@@ -654,6 +665,22 @@ fn decode_int256_parts_renders_as_string() {
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 #[test]
+fn decode_int256_parts_renders_as_string_negative() {
+    let value = Int256Parts {
+        hi_hi: -1,
+        hi_lo: 0,
+        lo_hi: 0,
+        lo_lo: 0,
+    };
+    let xdr = value.to_xdr_base64(Limits::none()).unwrap();
+    assert_eq!(
+        stellar_xdr_json::decode("Int256Parts".to_string(), xdr),
+        Ok("\"-6277101735386680763835789423207666416102355444464034512896\"".to_string()),
+    );
+}
+
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+#[test]
 fn decode_scval_u128_renders_as_string() {
     let value = ScVal::U128(UInt128Parts { hi: 1, lo: 2 });
     let xdr = value.to_xdr_base64(Limits::none()).unwrap();
@@ -671,6 +698,17 @@ fn decode_scval_i128_renders_as_string() {
     assert_eq!(
         stellar_xdr_json::decode("ScVal".to_string(), xdr),
         Ok("{\"i128\":\"18446744073709551618\"}".to_string()),
+    );
+}
+
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+#[test]
+fn decode_scval_i128_renders_as_string_negative() {
+    let value = ScVal::I128(Int128Parts { hi: -1, lo: 0 });
+    let xdr = value.to_xdr_base64(Limits::none()).unwrap();
+    assert_eq!(
+        stellar_xdr_json::decode("ScVal".to_string(), xdr),
+        Ok("{\"i128\":\"-18446744073709551616\"}".to_string()),
     );
 }
 
@@ -703,5 +741,56 @@ fn decode_scval_i256_renders_as_string() {
     assert_eq!(
         stellar_xdr_json::decode("ScVal".to_string(), xdr),
         Ok("{\"i256\":\"6277101735386680764516354157049543343084444891548699590660\"}".to_string()),
+    );
+}
+
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+#[test]
+fn decode_scval_i256_renders_as_string_negative() {
+    let value = ScVal::I256(Int256Parts {
+        hi_hi: -1,
+        hi_lo: 0,
+        lo_hi: 0,
+        lo_lo: 0,
+    });
+    let xdr = value.to_xdr_base64(Limits::none()).unwrap();
+    assert_eq!(
+        stellar_xdr_json::decode("ScVal".to_string(), xdr),
+        Ok(
+            "{\"i256\":\"-6277101735386680763835789423207666416102355444464034512896\"}"
+                .to_string()
+        ),
+    );
+}
+
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+#[test]
+fn encode_scval_i128_from_string() {
+    let json = r#"{"i128":"-18446744073709551616"}"#.to_string();
+    let xdr = stellar_xdr_json::encode("ScVal".to_string(), json.clone()).unwrap();
+    assert_eq!(stellar_xdr_json::decode("ScVal".to_string(), xdr), Ok(json),);
+}
+
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+#[test]
+fn encode_scval_i256_from_string() {
+    let json =
+        r#"{"i256":"-57896044618658097711785492504343953926634992332820282019728792003956564819968"}"#
+            .to_string();
+    let xdr = stellar_xdr_json::encode("ScVal".to_string(), json.clone()).unwrap();
+    assert_eq!(stellar_xdr_json::decode("ScVal".to_string(), xdr), Ok(json),);
+}
+
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+#[test]
+fn decode_int128_parts_min_boundary() {
+    let value = Int128Parts {
+        hi: i64::MIN,
+        lo: 0,
+    };
+    let xdr = value.to_xdr_base64(Limits::none()).unwrap();
+    assert_eq!(
+        stellar_xdr_json::decode("Int128Parts".to_string(), xdr),
+        Ok("\"-170141183460469231731687303715884105728\"".to_string()),
     );
 }


### PR DESCRIPTION
### What
Bump the stellar-xdr dependency to 26.0.1 and expand test coverage for i128/i256 rendering with negative and boundary values.

### Why
Track the latest stellar-xdr release and guard against regressions in signed 128/256-bit integer JSON rendering at edge cases.

Close #35 