### PR TITLE
Add stellar-xdr dependabot auto-updates with a Copilot fix handoff

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,9 @@ updates:
       day: "sunday"
       time: "02:00"
     open-pull-requests-limit: 2
+    # stellar-xdr is handled by the dedicated entry below.
+    ignore:
+      - dependency-name: "stellar-xdr"
     groups:
       minor-and-patch:
         applies-to: version-updates
@@ -17,6 +20,17 @@ updates:
         applies-to: version-updates
         update-types:
         - "major"
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "17:00"
+      timezone: "America/Los_Angeles"
+    open-pull-requests-limit: 1
+    allow:
+      - dependency-name: "stellar-xdr"
+    reviewers:
+      - "stellar/devx-eng"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/workflows/copilot-fix-stellar-xdr.yml
+++ b/.github/workflows/copilot-fix-stellar-xdr.yml
@@ -1,0 +1,65 @@
+name: Copilot Fix stellar-xdr
+
+# When the Rust CI fails on the dependabot PR that updates stellar-xdr, leave
+# an @copilot comment on the PR so the Copilot coding agent investigates and
+# pushes a fix. This workflow is scoped to only the stellar-xdr dependabot PR
+# (branch prefix `dependabot/cargo/stellar-xdr-`) — other dependabot PRs are
+# not affected.
+
+on:
+  workflow_run:
+    workflows: ["Rust"]
+    types: [completed]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+
+  request-copilot-fix:
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'failure' &&
+      github.event.workflow_run.actor.login == 'dependabot[bot]' &&
+      startsWith(github.event.workflow_run.head_branch, 'dependabot/cargo/stellar-xdr-')
+    runs-on: ubuntu-latest
+    steps:
+    - name: Find the PR
+      id: pr
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const run = context.payload.workflow_run;
+          const { data: prs } = await github.rest.pulls.list({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            head: `${context.repo.owner}:${run.head_branch}`,
+            state: 'open',
+          });
+          if (prs.length === 0) {
+            core.info(`No open PR found for head branch ${run.head_branch}`);
+            return;
+          }
+          core.setOutput('number', prs[0].number);
+
+    - name: Comment to hand off to Copilot
+      if: steps.pr.outputs.number != ''
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const run = context.payload.workflow_run;
+          const body = [
+            `@copilot the \`Rust\` CI failed on this \`stellar-xdr\` update.`,
+            ``,
+            `Please investigate the failure in [workflow run #${run.id}](${run.html_url}), push any source changes required to adopt the new \`stellar-xdr\` version onto this branch, and ensure CI passes.`,
+            ``,
+            `cc @stellar/devx-eng`,
+          ].join('\n');
+          await github.rest.issues.createComment({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: Number('${{ steps.pr.outputs.number }}'),
+            body,
+          });


### PR DESCRIPTION
### What
Add a dedicated Cargo dependabot entry that tracks only the internal dependencies, i.e. `stellar-xdr`, on a daily schedule, and exclude `stellar-xdr` from the existing Cargo group so its updates are isolated. Add a `copilot-fix-stellar-xdr.yml` workflow that, when the Rust CI fails on a `dependabot/cargo/stellar-xdr-` PR, posts an `@copilot` comment asking the Copilot coding agent to investigate the failure and push source changes to make the adoption of the new version work.

### Why
`stellar-xdr` is the internal dependency that when updated triggers us to need to update this repo. Sometimes updating `stellar-xdr` requires code changes beyond a version bump, which breaks the standard dependabot flow. Isolating it and handing failing CI off to Copilot automates the adaptation work and keeps the review scoped to devx-eng.

This PR is somewhat an experiment in seeing how well something like this will work for other more demanding repos.

Close https://github.com/stellar/pod-fsr/issues/32