### PR TITLE
Remove general cargo and github-actions dependabot configs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,26 +3,6 @@ updates:
   - package-ecosystem: "cargo"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "sunday"
-      time: "02:00"
-    open-pull-requests-limit: 2
-    # stellar-xdr is handled by the dedicated entry below.
-    ignore:
-      - dependency-name: "stellar-xdr"
-    groups:
-      minor-and-patch:
-        applies-to: version-updates
-        update-types:
-        - "patch"
-        - "minor"
-      major:
-        applies-to: version-updates
-        update-types:
-        - "major"
-  - package-ecosystem: "cargo"
-    directory: "/"
-    schedule:
       interval: "daily"
       time: "17:00"
       timezone: "America/Los_Angeles"
@@ -31,14 +11,3 @@ updates:
       - dependency-name: "stellar-xdr"
     reviewers:
       - "stellar/devx-eng"
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-      day: "sunday"
-      time: "02:00"
-    open-pull-requests-limit: 2
-    groups:
-      all-actions:
-        applies-to: version-updates
-        patterns: [ "*" ]


### PR DESCRIPTION
### What
Remove the general cargo and github-actions dependabot update entries, keeping only the dedicated stellar-xdr cargo entry.

### Why
Reduce dependabot noise by scoping automated updates to the stellar-xdr dependency that matters for this repo. Security dependabot updates are covered by the org level dependabot settings anyway.

Close https://github.com/stellar/pod-fsr/issues/32