### PR TITLE
Use OAuth token for Claude Code action

### DIFF
--- a/.github/workflows/claude-fix-stellar-xdr.yml
+++ b/.github/workflows/claude-fix-stellar-xdr.yml
@@ -55,7 +55,7 @@ jobs:
       if: steps.pr.outputs.number != ''
       uses: anthropics/claude-code-action@v1
       with:
-        anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+        claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
         prompt: |
           The `Rust` CI failed on PR #${{ steps.pr.outputs.number }}, which is a dependabot update of the `stellar-xdr` crate.
 


### PR DESCRIPTION
### What
Switch the claude-fix-stellar-xdr workflow from `ANTHROPIC_API_KEY` to `CLAUDE_CODE_OAUTH_TOKEN` for authenticating the Claude Code action.

### Why
OAuth token authentication is the supported credential for the Claude Code GitHub action.