### PR TITLE
Harden Claude fix workflow security

### DIFF
--- a/.github/workflows/claude-fix-stellar-xdr.yml
+++ b/.github/workflows/claude-fix-stellar-xdr.yml
@@ -12,8 +12,8 @@ on:
     types: [completed]
 
 # Revoke all default GITHUB_TOKEN permissions at the workflow level. The job
-# below opts in to what it needs. Defense in depth: a future job added without
-# its own `permissions:` block inherits nothing.
+# below opts in to what it needs, so a future job added without its own
+# `permissions:` block inherits nothing.
 permissions: {}
 
 jobs:
@@ -60,7 +60,6 @@ jobs:
       uses: anthropics/claude-code-action@v1
       with:
         claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-        show_full_output: false
         prompt: |
           The `Rust` CI failed on PR #${{ steps.pr.outputs.number }}, which is a dependabot update of the `stellar-xdr` crate.
 
@@ -68,4 +67,4 @@ jobs:
         # --max-turns caps how many tool-use cycles Claude can run, which bounds
         # token spend per invocation.
         claude_args: |
-          --max-turns 50
+          --max-turns 30

--- a/.github/workflows/claude-fix-stellar-xdr.yml
+++ b/.github/workflows/claude-fix-stellar-xdr.yml
@@ -11,10 +11,10 @@ on:
     workflows: ["Rust"]
     types: [completed]
 
-permissions:
-  contents: write
-  pull-requests: write
-  issues: write
+# Revoke all default GITHUB_TOKEN permissions at the workflow level. The job
+# below opts in to what it needs. Defense in depth: a future job added without
+# its own `permissions:` block inherits nothing.
+permissions: {}
 
 jobs:
 
@@ -25,6 +25,10 @@ jobs:
       github.event.workflow_run.actor.login == 'dependabot[bot]' &&
       startsWith(github.event.workflow_run.head_branch, 'dependabot/cargo/stellar-xdr-')
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
     steps:
     - name: Find the PR
       id: pr
@@ -56,7 +60,12 @@ jobs:
       uses: anthropics/claude-code-action@v1
       with:
         claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+        show_full_output: false
         prompt: |
           The `Rust` CI failed on PR #${{ steps.pr.outputs.number }}, which is a dependabot update of the `stellar-xdr` crate.
 
           Investigate the failure in workflow run ${{ github.event.workflow_run.html_url }}, push any source changes required to adopt the new `stellar-xdr` version onto this branch, and ensure CI passes.
+        # --max-turns caps how many tool-use cycles Claude can run, which bounds
+        # token spend per invocation.
+        claude_args: |
+          --max-turns 50


### PR DESCRIPTION
### What

Apply the best practices to the `claude-fix-stellar-xdr` workflow:

- Move the broad `contents: write`/`pull-requests: write`/`issues: write` scope from workflow level to the single job that needs it; set top-level `permissions: {}` so any future job added to this file inherits nothing by default.
- Add `--max-turns 30` via `claude_args` to bound token spend per invocation.

The workflow's existing structural restrictions are kept:
- Trigger restricted to `workflow_run` of the `Rust` workflow with `conclusion == 'failure'`.
- Actor restricted to `dependabot[bot]`.
- Head branch restricted to `dependabot/cargo/stellar-xdr-` prefix.

The pull-request-target/`pr-head` subdir pattern and `MEMBER`/`OWNER` author-association gate (used by the `claude-review.yml` style) do not apply here: the trigger is `workflow_run`, not `pull_request_target`, and the actor gate (dependabot only) plays the equivalent role.

### Why

Brings this workflow in line with the Claude-action security standards being applied across the stellar org (see `stellar/stellar-core` [PR #5258](https://github.com/stellar/stellar-core/pull/5258) and the [claude-code-action security guide](https://github.com/anthropics/claude-code-action/blob/main/docs/security.md)). The two specific gaps closed:

- Without `--max-turns`, a stuck-in-a-loop run could burn an unbounded number of tokens.
- Without `permissions: {}` at the workflow root, any future job added to this file would silently inherit the broad write scopes. Moving them to the job level limits the blast radius.