### PR TITLE
SPIKE: Protocol 27 — CAP-71 / CAP-83 support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -543,9 +543,8 @@ dependencies = [
 
 [[package]]
 name = "stellar-xdr"
-version = "26.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea6e29c7e1f071c2767916460d006668197843d5d93f0ec8893a26f72a14f595"
+version = "26.0.0"
+source = "git+https://github.com/stellar/rs-stellar-xdr?rev=a749b69b3471aec0c20ec431b0297f3414d66421#a749b69b3471aec0c20ec431b0297f3414d66421"
 dependencies = [
  "base64",
  "cfg_eval",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,11 +21,12 @@ console_error_panic_hook = { version = "0.1.7", optional = true }
 # TODO: For use with generating native values.
 # serde-wasm-bindgen = "0.6.5"
 
+# CAP-71 pre-release: per-cap-feature layout, no 'curr' module.
 [dependencies.stellar-xdr]
-version = "26.0.1"
-features = ["std", "curr", "base64", "serde", "serde_json", "schemars"]
-# git = "https://github.com/stellar/rs-stellar-xdr"
-# rev = "89a8bcde36aeda551cb0e3f9aa3e9fcf315fe1cc"
+version = "26.0.0"
+git = "https://github.com/stellar/rs-stellar-xdr"
+rev = "a749b69b3471aec0c20ec431b0297f3414d66421"
+features = ["std", "cap_0071", "base64", "serde", "serde_json", "schemars"]
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.34"
@@ -42,4 +43,6 @@ strip = "symbols"
 debug-assertions = false
 
 [package.metadata.wasm-pack.profile.release]
-wasm-opt = ["-O", "--enable-bulk-memory"]
+# wasm-opt disabled — local binaryen rejects the bulk-memory ops emitted by the
+# rs-stellar-xdr @ a749b69b dep. Output is unoptimized but functionally correct.
+wasm-opt = false

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@ mod console_error_panic_hook;
 use schemars::gen::SchemaSettings;
 use std::io::Cursor;
 use std::str::FromStr;
-use stellar_xdr::curr::{Limited, Limits, Type, TypeVariant, WriteXdr};
+use stellar_xdr::{Limited, Limits, Type, TypeVariant, WriteXdr};
 use wasm_bindgen::prelude::*;
 
 // This is set to mirror https://github.com/stellar/rs-soroban-env/blob/main/soroban-env-host/src/budget/limits.rs#L14


### PR DESCRIPTION
SPIKE used to render CAP-71 transactions in stellar-laboratory. Companion PR: stellar/js-stellar-base#972 (the XDR regen). See branch commits for details.