### PR TITLE
SPIKE: Protocol 28 (CAP-0085)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,6 +117,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "crate-git-revision"
+version = "0.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54851b5b3f24621804b1cded2820975623c205e3055d2d44031cdb1237339ac8"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "serde_json",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -537,19 +548,18 @@ version = "0.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee1832fb50c651ad10f734aaf5d31ca5acdfb197a6ecda64d93fcdb8885af913"
 dependencies = [
- "crate-git-revision",
+ "crate-git-revision 0.0.6",
  "data-encoding",
 ]
 
 [[package]]
 name = "stellar-xdr"
 version = "27.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05ff843326969bdf1ef673dcdba94c08f4a3c8f1e58d6e6ef39b1bd4f749179a"
+source = "git+https://github.com/sisuresh/rs-stellar-xdr?rev=e1170cd9abb9d1d10cf4a3b7ed4091a109f56b71#e1170cd9abb9d1d10cf4a3b7ed4091a109f56b71"
 dependencies = [
  "base64",
  "cfg_eval",
- "crate-git-revision",
+ "crate-git-revision 0.0.9",
  "escape-bytes",
  "ethnum",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,11 +21,16 @@ console_error_panic_hook = { version = "0.1.7", optional = true }
 # TODO: For use with generating native values.
 # serde-wasm-bindgen = "0.6.5"
 
+# Protocol 28 (CAP-0085) pre-release: pinned to rs-stellar-xdr#553
+# (e1170cd9abb9d1d10cf4a3b7ed4091a109f56b71), whose xdr submodule is
+# stellar-xdr#308 head (76218a994f8c5ba752cba368080fb2f89843ad3c).
+# cap_0085_executable_ref adds the externally-managed contract-executable types
+# (ContractExecutableExternalRef, SCV_EXECUTABLE_TAG, CONTRACT_EXECUTABLE_EXTERNAL_REF).
 [dependencies.stellar-xdr]
 version = "27.0.0"
-features = ["std", "base64", "serde", "serde_json", "schemars", "type_enum"]
-# git = "https://github.com/stellar/rs-stellar-xdr"
-# rev = "89a8bcde36aeda551cb0e3f9aa3e9fcf315fe1cc"
+git = "https://github.com/sisuresh/rs-stellar-xdr"
+rev = "e1170cd9abb9d1d10cf4a3b7ed4091a109f56b71"
+features = ["std", "base64", "serde", "serde_json", "schemars", "type_enum", "cap_0085_executable_ref"]
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.34"
@@ -42,4 +47,7 @@ strip = "symbols"
 debug-assertions = false
 
 [package.metadata.wasm-pack.profile.release]
-wasm-opt = ["-O", "--enable-bulk-memory"]
+# wasm-opt disabled — local binaryen may reject the bulk-memory ops emitted by the
+# rs-stellar-xdr pre-release dep. Output is unoptimized but functionally correct.
+# Re-enable once the pinned rev lands a crates.io release.
+wasm-opt = false

--- a/deny.toml
+++ b/deny.toml
@@ -35,8 +35,9 @@ allow = [
 ]
 deny = [
 ]
-skip = [
-]
+# SPIKE (p28-cap-0085): git-pinned stellar-xdr pulls crate-git-revision 0.0.9 while
+# crates.io stellar-strkey pulls 0.0.6. Remove when the pin flips to version=.
+skip = [{ name = "crate-git-revision", version = "0.0.6" }]
 skip-tree = [
 ]
 
@@ -44,7 +45,9 @@ skip-tree = [
 unknown-registry = "deny"
 unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
-allow-git = []
+# SPIKE (p28-cap-0085): stellar-xdr is git-pinned to rs-stellar-xdr#553 (fork) until it
+# releases on crates.io. Revert to allow-git = [] when the pin flips to version=.
+allow-git = ["https://github.com/sisuresh/rs-stellar-xdr"]
 
 [sources.allow-org]
 github = []

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -110,6 +110,7 @@ fn list_of_types() {
             "UInt256Parts",
             "Int256Parts",
             "ContractExecutableType",
+            "ContractExecutableExternalRef",
             "ContractExecutable",
             "ScAddressType",
             "MuxedEd25519Account",


### PR DESCRIPTION
SPIKE for Protocol 28 (CAP-0085 — externally managed contract executables). Bumps the WASM XDR↔JSON codec's `stellar-xdr` to the CAP-0085 pre-release.

## Changes
- Pin `stellar-xdr` → `sisuresh/rs-stellar-xdr@e1170cd9` (rs-stellar-xdr#553; xdr submodule = stellar-xdr#308 head `76218a99`), feature `cap_0085_executable_ref` (base `main` enables no cap flags, so only this one is added — not `cap_0083`/`cap_0084`).
- New type `ContractExecutableExternalRef` in `list_of_types` test.
- `wasm-opt = false` (local binaryen rejects the pre-release dep's bulk-memory ops).
- `deny.toml`: allow the fork git source + skip `crate-git-revision` dup (SPIKE-only).

## Deferred
- `wasm-pack test` (headless firefox) not run locally; native `cargo test` passes — relies on CI for the browser leg.

Upstream: stellar/rs-stellar-xdr#553 (canonical `.x`: stellar/stellar-xdr#308).
Downstream: stellar/laboratory (consumes `@stellar/stellar-xdr-json`).
